### PR TITLE
instructions for keras models

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ docker run -it -p 8888:8888 -v /Users/yourname/data:/home/docker/fastai-courses/
 
 Your local data directory will now be visible in the container at `/home/docker/data`.
 
-The notebooks are setup to save keras models to `/home/docker/.keras/models`.
+The notebooks save keras models to `/tmp/.keras/models`,
 You can create another volume for the models so the data persists.
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The notebooks are setup to save keras models to `/home/docker/.keras/models`.
 You can create another volume for the models so the data persists.
 
 ```bash
-docker run -it -p 8888:8888 -v /Users/yourname/data:/home/docker/fastai-courses/deeplearning1/nbs/data -v /Users/yourname/models:/home/docker/.keras/models deeprig/fastai-course-1
+docker run -it -p 8888:8888 -v /Users/yourname/data:/home/docker/fastai-courses/deeplearning1/nbs/data -v /Users/yourname/models:/tmp/.keras/models deeprig/fastai-course-1
 ```
 
 ## Installing packages

--- a/README.md
+++ b/README.md
@@ -28,10 +28,17 @@ Docker containers are designed to be ephemeral, so if you need persistent data f
 For example, if your data directory is at `/Users/yourname/data`, start your container with this command:
 
 ```bash
-docker run -it -p 8888:8888 -v /Users/yourname/data:/home/docker/data deeprig/fastai-course-1
+docker run -it -p 8888:8888 -v /Users/yourname/data:/home/docker/fastai-courses/deeplearning1/nbs/data deeprig/fastai-course-1
 ```
 
 Your local data directory will now be visible in the container at `/home/docker/data`.
+
+The notebooks are setup to save keras models to `/home/docker/.keras/models`.
+You can create another volume for the models so the data persists.
+
+```bash
+docker run -it -p 8888:8888 -v /Users/yourname/data:/home/docker/fastai-courses/deeplearning1/nbs/data -v /Users/yourname/models:/home/docker/.keras/models deeprig/fastai-course-1
+```
 
 ## Installing packages
 All packages should ideally be part of the Dockerfile. If something is missing, please open an issue or submit a PR to update the Dockerfile. If you need to install something as a workaround, follow the steps below:


### PR DESCRIPTION
Updated the first volume example to point to the directory the notebooks are in. I also added instructions for mounting an additional volume for the keras models. After digging through the code, I saw that the models were being saved the `/tmp` and obviously destroyed after stopping a container. Mounting another volume should help with subsequent runs.