### PR TITLE
Install Keras 1.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ RUN conda install -y --quiet python=$PYTHON_VERSION && \
   matplotlib pandas bcolz sympy scikit-image && \
   pip install --upgrade pip && \
   pip install tensorflow-gpu kaggle-cli && \
-  pip install git+git://github.com/fchollet/keras.git && \
+  pip install git+git://github.com/fchollet/keras.git@1.1.2 && \
   conda clean -tipsy
 
 ENV CUDA_HOME=/usr/local/cuda


### PR DESCRIPTION
2.x is very new, and is not compatible with the fast-ai course notes.


Specifically, installing Keras 1 (what this PR does) instead of 2 will fix the error `cannot import activity_l2`  when running the lesson1 notebook.