### PR TITLE
Add Explicit nvidia-docker Command to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,15 @@ The container comes with:
 * ...all other libraries needed for the course.
 
 ## Usage
+
+#### CPU Only
 ```bash
 docker run -it -p 8888:8888 deeprig/fastai-course-1
+```
+
+#### With GPU
+```bash
+nvidia-docker run -it -p 8888:8888 deeprig/fastai-course-1
 ```
 
 ## Data management


### PR DESCRIPTION
This is to prevent a stumbling block. Personally, I had nvidia-docker installed (never used it before though) and the instructions said to run it with simply `docker`, so I thought that that would be enough to get GPU support, but it was not. :)